### PR TITLE
Fix #40 - Pin azure-ai-projects to 1.1.0b2 to avoid version resolution issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Azure SDK and AI Services
 azure-identity>=1.24.0
-azure-ai-projects>=1.1.0b2
+azure-ai-projects==1.1.0b2
 azure-ai-inference[opentelemetry]>=1.0.0b9
 azure-ai-evaluation>=1.10.0
 azure-ai-contentsafety>=1.0.0


### PR DESCRIPTION
This change pins `azure-ai-projects` to version 1.1.0b2 instead of using a version range.
Pinning the dependency ensures consistent installs and avoids unexpected breakages caused by newer beta releases.